### PR TITLE
fix!: allow clients to write data when using `SecurityAttributes::allow_everyone_connect()`

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,11 +1,9 @@
 use futures_util::StreamExt as _;
-use tipsy::{Endpoint, OnConflict, SecurityAttributes, ServerId};
+use tipsy::{Endpoint, OnConflict, ServerId};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, split};
 
 async fn run_server(path: String) {
-    let endpoint = Endpoint::new(ServerId::new(path), OnConflict::Overwrite)
-        .unwrap()
-        .security_attributes(SecurityAttributes::allow_everyone_create().unwrap());
+    let endpoint = Endpoint::new(ServerId::new(path), OnConflict::Overwrite).unwrap();
 
     let incoming = endpoint.incoming().expect("failed to open new socket");
     futures_util::pin_mut!(incoming);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,16 +154,22 @@ impl SecurityAttributes {
     }
 
     /// New default security attributes that allow everyone to connect.
-    pub fn allow_everyone_connect(self) -> io::Result<Self> {
-        Ok(Self(self.0.allow_everyone_connect()?))
+    ///
+    /// On Windows, this is equivalent to [`SecurityAttributes::allow_everyone_create`].
+    pub fn allow_everyone_connect() -> io::Result<Self> {
+        Ok(Self(platform::SecurityAttributes::allow_everyone_connect()?))
     }
 
     /// Set a custom permission on the socket.
-    pub fn set_mode(self, mode: u16) -> io::Result<Self> {
-        Ok(Self(self.0.set_mode(mode)?))
+    ///
+    /// Has no effect on Windows.
+    pub fn mode(self, mode: u16) -> io::Result<Self> {
+        Ok(Self(self.0.mode(mode)?))
     }
 
     /// New default security attributes that allow everyone to create.
+    ///
+    /// On Windows, this is equivalent to [`SecurityAttributes::allow_everyone_connect`].
     pub fn allow_everyone_create() -> io::Result<Self> {
         Ok(Self(platform::SecurityAttributes::allow_everyone_create()?))
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -36,14 +36,12 @@ impl SecurityAttributes {
         Self { mode: Some(0o600) }
     }
 
-    pub(crate) fn allow_everyone_connect(mut self) -> io::Result<Self> {
-        self.mode = Some(0o666);
-        Ok(self)
+    pub(crate) fn allow_everyone_connect() -> io::Result<Self> {
+        Ok(Self { mode: Some(0o666) })
     }
 
-    pub(crate) fn set_mode(mut self, mode: u16) -> io::Result<Self> {
-        self.mode = Some(mode);
-        Ok(self)
+    pub(crate) fn mode(self, mode: u16) -> io::Result<Self> {
+        Ok(Self { mode: Some(mode) })
     }
 
     pub(crate) fn allow_everyone_create() -> io::Result<Self> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -19,7 +19,6 @@ use windows_sys::Win32::Security::{
     PSID, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR, SID_IDENTIFIER_AUTHORITY,
     SetSecurityDescriptorDacl,
 };
-use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_DATA;
 use windows_sys::Win32::System::Memory::{LPTR, LocalAlloc};
 use windows_sys::Win32::System::SystemServices::{
     SECURITY_DESCRIPTOR_REVISION, SECURITY_WORLD_RID,
@@ -242,14 +241,11 @@ impl SecurityAttributes {
         DEFAULT_SECURITY_ATTRIBUTES
     }
 
-    pub(crate) fn allow_everyone_connect(self) -> io::Result<Self> {
-        let attributes = Some(InnerAttributes::allow_everyone(
-            GENERIC_READ | FILE_WRITE_DATA,
-        )?);
-        Ok(Self { attributes })
+    pub(crate) fn allow_everyone_connect() -> io::Result<Self> {
+        Self::allow_everyone_create()
     }
 
-    pub(crate) fn set_mode(self, _mode: u16) -> io::Result<Self> {
+    pub(crate) fn mode(self, _mode: u16) -> io::Result<Self> {
         // for now, does nothing.
         Ok(self)
     }


### PR DESCRIPTION
Resolves #19 

We currently don't set the `GENERIC_WRITE` permission when using the `allow_everyone_connect()` option. [However, it appears this permission is required when using `PIPE_ACCESS_OUTBOUND`](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights). This library is currently only designed for full duplex communication, so I don't think it's possible to limit these permissions. As a result, I think `allow_everyone_connect` and `allow_everyone_create` will need to be equivalent on Windows.

This PR also refactors the `SecurityAttributes` methods for consistency.